### PR TITLE
Integration of the Shopify Active Merchant Logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
 
+gem 'pry'
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 2.50.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,13 @@
 source 'https://rubygems.org'
+
+group :test, :remote_test do
+  gem 'pry-rails'
+end
+
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
 
-gem 'pry'
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
   gem 'braintree', '>= 2.50.0'

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('thor')
+  s.add_development_dependency('shopify_api', '~> 4.0')
 end

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://activemerchant.org/'
   s.rubyforge_project = 'activemerchant'
 
-  s.required_ruby_version = '>= 2'
+  s.required_ruby_version = '>= 2.3'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/lib/active_merchant/billing/gateways/shopify.rb
+++ b/lib/active_merchant/billing/gateways/shopify.rb
@@ -51,19 +51,22 @@ end
 
 class ShopifyVoider
   def initialize(transaction_id, order_id)
+    @order_id = order_id
     @transaction = ::ShopifyAPI::Transaction.find(transaction_id, params: { order_id: order_id })
   end
 
   def perform
     raise ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError if transaction.nil?
 
-    transaction.kind = 'void'
-    transaction.save
+    options = { order_id: order_id, reason: 'Payment voided' }
+    full_amount_to_cents = BigDecimal.new(transaction.amount) * 100
+    refunder = ShopifyRefunder.new(full_amount_to_cents, transaction.id, options)
+    refunder.perform
   end
 
   private
 
-  attr_reader :transaction
+  attr_reader :transaction, :order_id
 end
 
 class ShopifyRefunder

--- a/lib/active_merchant/billing/gateways/shopify.rb
+++ b/lib/active_merchant/billing/gateways/shopify.rb
@@ -1,0 +1,113 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class ShopifyGateway < Gateway
+      class TransactionNotFoundError < Error; end
+
+      self.homepage_url = 'https://shopify.ca/'
+      self.display_name = 'Shopify'
+
+      def initialize(options = {})
+        requires!(options, :login)
+        @api_key = options[:api_key]
+        @password = options[:password]
+        @shop_name = options[:shop_name]
+        init_shopify_api!
+
+        super
+      end
+
+      def void(transaction_id, options = {})
+        order_id = options[:order_id]
+        voider = ShopifyVoider.new(transaction_id, order_id)
+        voider.perform
+      end
+
+      def refund(money, transaction_id, options = {})
+        refund = options[:originator]
+        refunder = ShopifyRefunder.new(money, transaction_id, refund)
+        refunder.perform
+      end
+
+      private
+
+      attr_reader :api_key, :password, :shop_name
+
+      def init_shopify_api!
+        ::ShopifyAPI::Base.site = shop_url
+      end
+
+      def shop_url
+        "https://#{api_key}:#{password}@#{shop_name}"
+      end
+    end
+  end
+end
+
+class ShopifyVoider
+  def initialize(transaction_id, order_id)
+    @transaction = ::ShopifyAPI::Transaction.find(transaction_id, params: { order_id: order_id })
+  end
+
+  def perform
+    raise TransactionNotFoundError if transaction.nil?
+
+    transaction.kind = 'void'
+    transaction.save
+  end
+
+  private
+
+  attr_reader :transaction
+end
+
+class ShopifyRefunder
+  def initialize(credited_money, transaction_id, refund)
+    @refund = refund
+    @credited_money = BigDecimal.new(credited_money)
+    @transaction = ::ShopifyAPI::Transaction.find(transaction_id, params: { order_id: pos_order_id })
+  end
+
+  def perform
+    if full_refund?
+      perform_full_refund_on_shopify
+    elsif partial_refund?
+      raise NotImplementedError
+    else
+      raise NotImplementedError
+    end
+  end
+
+  private
+
+  def perform_full_refund_on_shopify
+    ::ShopifyAPI::Refund.create({ shipping: { full_refund: true },
+                                  note: refund.reason.name,
+                                  notify: false,
+                                  restock: false,
+                                  transaction: suggested_transaction },
+                                params: { order_id: pos_order_id })
+  end
+
+  def suggested_transaction
+    ::ShopifyAPI::Refund.calculate({ shipping: { full_refund: true } },
+                                   params: { order_id: pos_order_id })
+  end
+
+  def pos_order_id
+    refund.pos_order_id
+  end
+
+  def full_refund?
+    credited_money == amount_to_cents(transaction.amount)
+  end
+
+  def partial_refund?
+    BigDecimal.new(credit_money) < amount_to_cents(transaction.amount)
+  end
+
+  def amount_to_cents(amount)
+    amount * 100
+  end
+
+  attr_accessor :credited_money, :refund, :transaction
+end

--- a/lib/active_merchant/billing/gateways/shopify.rb
+++ b/lib/active_merchant/billing/gateways/shopify.rb
@@ -7,7 +7,9 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'Shopify'
 
       def initialize(options = {})
-        requires!(options, :login)
+        requires!(options, :api_key)
+        requires!(options, :password)
+        requires!(options, :shop_name)
         @api_key = options[:api_key]
         @password = options[:password]
         @shop_name = options[:shop_name]

--- a/lib/active_merchant/billing/gateways/shopify.rb
+++ b/lib/active_merchant/billing/gateways/shopify.rb
@@ -1,3 +1,5 @@
+require 'shopify_api'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class ShopifyGateway < Gateway
@@ -51,7 +53,8 @@ class ShopifyVoider
   end
 
   def perform
-    raise TransactionNotFoundError if transaction.nil?
+    raise ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError if transaction.nil?
+
 
     transaction.kind = 'void'
     transaction.save

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -942,6 +942,12 @@ spreedly_core:
   password: "Y2i7AjgU03SUjwY4xnOPqzdsv4dMbPDCQzorAk8Bcoy0U8EIVE4innGjuoMQv7MN"
   gateway_token: "3gLeg4726V5P0HK7cq7QzHsL0a6"
 
+# Replace with your own credentials
+shopify:
+  api_key: "d5719fb9c960c45ad1418675b9c725c4"
+  password: "4ac8651236acbd5e5ffccc8c5458c4df"
+  shop_name: "dynamo-staging.myshopify.com/admin"
+
 # Working credentials, no need to replace
 stripe:
   login: sk_test_3OD4TdKSIOhDOL2146JJcC79

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -944,9 +944,9 @@ spreedly_core:
 
 # Replace with your own credentials
 shopify:
-  api_key: "d5719fb9c960c45ad1418675b9c725c4"
-  password: "4ac8651236acbd5e5ffccc8c5458c4df"
-  shop_name: "dynamo-staging.myshopify.com/admin"
+  api_key: "use"
+  password: "your"
+  shop_name: "own"
 
 # Working credentials, no need to replace
 stripe:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ require 'json'
 require 'active_merchant'
 require 'comm_stub'
 
+require 'pry'
+
 require 'active_support/core_ext/integer/time'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/time/acts_like'

--- a/test/unit/gateways/remote_shopify_test.rb
+++ b/test/unit/gateways/remote_shopify_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class RemoteStripeTest < Test::Unit::TestCase
+  def setup
+    @gateway = ShopifyGateway.new(fixtures(:shopify))
+
+    @order = create_shopify_order
+    @transaction = ::ShopifyAPI::Order.find(@order.id).transactions.first
+    @amount = BigDecimal.new(@transaction.amount) * 100
+
+    @options = { order_id: @order.id, reason: 'Object is malfunctioning' }
+  end
+
+  def teardown
+    @order.destroy
+  end
+
+  def test_successful_full_refund
+    assert response = @gateway.refund(@amount, @transaction.id, @options)
+    assert_success response
+  end
+
+  private
+
+  def create_shopify_order
+    order = ::ShopifyAPI::Order.new
+    order.email = 'cab@godynamo.com'
+    order.fulfillment_status = 'partial'
+    order.line_items = [
+      {
+        variant_id: '447654529',
+        quantity: 1,
+        name: 'test',
+        price: 140,
+        title: 'title'
+      }
+    ]
+    order.customer = { first_name: 'Paul',
+                       last_name: 'Norman',
+                       email: 'paul.norman@example.com' }
+
+    order.billing_address = {
+      first_name: 'John',
+      last_name: 'Smith',
+      address1: '123 Fake Street',
+      phone: '555-555-5555',
+      city: 'Fakecity',
+      province: 'Ontario',
+      country: 'Canada',
+      zip: 'K2P 1L4'
+    }
+    order.shipping_address = {
+      first_name: 'John',
+      last_name: 'Smith',
+      address1: '123 Fake Street',
+      phone: '555-555-5555',
+      city: 'Fakecity',
+      province: 'Ontario',
+      country: 'Canada',
+      zip: 'K2P 1L4'
+    }
+    order.transactions = [
+      {
+        kind: 'authorization',
+        status: 'success',
+        amount: 50.0
+      }
+    ]
+    order.financial_status = 'partially_paid'
+    order.save
+
+    order
+  end
+end
+

--- a/test/unit/gateways/remote_shopify_test.rb
+++ b/test/unit/gateways/remote_shopify_test.rb
@@ -9,15 +9,26 @@ class RemoteStripeTest < Test::Unit::TestCase
     @order = create_fulfilled_paid_shopify_order
     @transaction = ::ShopifyAPI::Order.find(@order.id).transactions.first
 
-    @options = { order_id: @order.id, reason: 'Object is malfunctioning' }
+    @refund_options = { order_id: @order.id, reason: 'Object is malfunctioning' }
+    @void_options = { order_id: @order.id, reason: 'Payment voided' }
   end
 
   def teardown
     @order.destroy
   end
 
+  def test_successful_void
+    assert response = @gateway.void(@transaction.id, @void_options)
+    assert_success response
+  end
+
   def test_successful_full_refund
-    assert response = @gateway.refund(@refund_amount_in_cents, @transaction.id, @options)
+    assert response = @gateway.refund(@refund_amount_in_cents, @transaction.id, @refund_options)
+    assert_success response
+  end
+
+  def test_successful_partial_refund
+    assert response = @gateway.refund(@refund_amount_in_cents / 2, @transaction.id, @refund_options)
     assert_success response
   end
 

--- a/test/unit/gateways/remote_shopify_test.rb
+++ b/test/unit/gateways/remote_shopify_test.rb
@@ -5,6 +5,7 @@ class RemoteStripeTest < Test::Unit::TestCase
     @gateway = ShopifyGateway.new(fixtures(:shopify))
 
     @refund_amount = 50
+    @refund_amount_in_cents = @refund_amount * 100
     @order = create_fulfilled_paid_shopify_order
     @transaction = ::ShopifyAPI::Order.find(@order.id).transactions.first
 
@@ -16,7 +17,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_full_refund
-    assert response = @gateway.refund(@refund_amount, @transaction.id, @options)
+    assert response = @gateway.refund(@refund_amount_in_cents, @transaction.id, @options)
     assert_success response
   end
 

--- a/test/unit/gateways/shopify_test.rb
+++ b/test/unit/gateways/shopify_test.rb
@@ -7,6 +7,17 @@ class ShopifyTest < Test::Unit::TestCase
                                   shop_name: 'shop_name')
   end
 
+  def test_void_calls_refund
+    transaction_id = 123
+    transaction = stub(amount: 1, id: transaction_id)
+    refunder_instance = stub(perform: true)
+    ::ShopifyAPI::Transaction.expects(:find).returns(transaction)
+    ShopifyRefunder.expects(:new).returns(refunder_instance)
+
+    refunder_instance.expects(:perform).once
+    @gateway.void(123, { order_id: '123' })
+  end
+
   def test_void_with_not_found_transaction
     ::ShopifyAPI::Transaction.expects(:find).returns(nil)
     assert_raises(::ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError) { @gateway.void(123, order_id: '123') }

--- a/test/unit/gateways/shopify_test.rb
+++ b/test/unit/gateways/shopify_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ShopifyTest < Test::Unit::TestCase
+  def setup
+    @gateway = ShopifyGateway.new(api_key: 'api_key',
+                                  password: 'password',
+                                  shop_name: 'shop_name')
+  end
+
+  def test_void_with_not_found_transaction
+    ::ShopifyAPI::Transaction.expects(:find).returns(nil)
+    assert_raises(::ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError) { @gateway.void(123, order_id: '123') }
+  end
+end

--- a/test/unit/gateways/shopify_test.rb
+++ b/test/unit/gateways/shopify_test.rb
@@ -18,17 +18,27 @@ class ShopifyTest < Test::Unit::TestCase
   end
 
   def test_refund_with_credit_to_big
-    transaction = stub(amount: 100)
+    transaction = stub(amount: 1)
     ::ShopifyAPI::Transaction.stubs(:find).returns(transaction)
-    assert_raises(::ActiveMerchant::Billing::ShopifyGateway::CreditedAmountBiggerThanTransaction) { @gateway.refund(1000, 123, { order_id: '123', reason: 'reason' }) }
+    assert_raises(::ActiveMerchant::Billing::ShopifyGateway::CreditedAmountBiggerThanTransaction) { @gateway.refund(10000, 123, { order_id: '123', reason: 'reason' }) }
   end
 
-  def test_full_refund
+  def test_response_value_of_unsuccessful_refund
     transaction_id = 123
-    transaction = stub(amount: 100, id: transaction_id)
-    refund = stub(success?: true)
+    transaction = stub(amount: 1, id: transaction_id)
+    refund = stub(errors: [])
     ::ShopifyAPI::Transaction.stubs(:find).returns(transaction)
     ::ShopifyAPI::Refund.stubs(:create).returns(refund)
     assert_success(@gateway.refund(100, transaction_id, { order_id: '123', reason: 'reason' }))
+  end
+
+  def test_reponse_value_of_successful_refund
+    transaction_id = 123
+    transaction = stub(amount: 1, id: transaction_id)
+    errors = stub(messages: { error: 'error1' })
+    refund = stub(errors: errors)
+    ::ShopifyAPI::Transaction.stubs(:find).returns(transaction)
+    ::ShopifyAPI::Refund.stubs(:create).returns(refund)
+    assert_failure(@gateway.refund(100, transaction_id, { order_id: '123', reason: 'reason' }))
   end
 end

--- a/test/unit/gateways/shopify_test.rb
+++ b/test/unit/gateways/shopify_test.rb
@@ -11,4 +11,24 @@ class ShopifyTest < Test::Unit::TestCase
     ::ShopifyAPI::Transaction.expects(:find).returns(nil)
     assert_raises(::ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError) { @gateway.void(123, order_id: '123') }
   end
+
+  def test_refund_with_not_found_transaction
+    ::ShopifyAPI::Transaction.expects(:find).returns(nil)
+    assert_raises(::ActiveMerchant::Billing::ShopifyGateway::TransactionNotFoundError) { @gateway.refund(123, 123, { order_id: '123', reason: 'reason' }) }
+  end
+
+  def test_refund_with_credit_to_big
+    transaction = stub(amount: 100)
+    ::ShopifyAPI::Transaction.stubs(:find).returns(transaction)
+    assert_raises(::ActiveMerchant::Billing::ShopifyGateway::CreditedAmountBiggerThanTransaction) { @gateway.refund(1000, 123, { order_id: '123', reason: 'reason' }) }
+  end
+
+  def test_full_refund
+    transaction_id = 123
+    transaction = stub(amount: 100, id: transaction_id)
+    refund = stub(success?: true)
+    ::ShopifyAPI::Transaction.stubs(:find).returns(transaction)
+    ::ShopifyAPI::Refund.stubs(:create).returns(refund)
+    assert_success(@gateway.refund(100, transaction_id, { order_id: '123', reason: 'reason' }))
+  end
 end


### PR DESCRIPTION
This PR contains the logic required for the ShopifyGateway (https://github.com/DynamoMTL/solidus_gateway/pull/1) to be able to void / refund an order. 

This will make call the proper calls to the ShopifyAPI and refund / void the order that are there with what is being passed to the Gateway.
